### PR TITLE
better us the repository field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 description = "A small command-line utility for reporting working time and displaying it in different formats."
 license = "MIT"
-homepage = "https://github.com/Godsmith/timereport"
+repository = "https://github.com/Godsmith/timereport"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it
See also [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field)
